### PR TITLE
feat(books): implements update book data

### DIFF
--- a/src/books/books.controller.ts
+++ b/src/books/books.controller.ts
@@ -214,9 +214,39 @@ export class BooksController {
     return this.booksService.findOne(isbn);
   }
 
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateBookDto: UpdateBookDto) {
-    return this.booksService.update(+id, updateBookDto);
+  @Rbca(['admin'], 'update', 'books')
+  @UseGuards(AuthorizationGuard)
+  @Patch(':isbn')
+  @ApiOperation({
+    summary: 'update a book by ISBN',
+    description:
+      'update book data using its ISBN. Throws an error if not found.',
+  })
+  @ApiParam({
+    name: 'isbn',
+    required: true,
+    description: 'The ISBN of the book to update.',
+    type: String,
+  })
+  @ApiOkResponse({
+    description: 'Book updated successfully.',
+    schema: {
+      example: {
+        success: 'true',
+        message: 'Book updated successfully.',
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: 'book not found with the provided isbn',
+    schema: {
+      example: {
+        message: 'Book not found with the provided isbn.',
+      },
+    },
+  })
+  update(@Param('isbn') isbn: string, @Body() updateBookDto: UpdateBookDto) {
+    return this.booksService.update(isbn, updateBookDto);
   }
 
   @Rbca(['admin'], 'delete', 'books')


### PR DESCRIPTION
Pull Request: Update Book by ISBN

Summary: This PR implements the functionality to update a book by its ISBN. The update operation includes a check for deletedAt = null to prevent updates on logically deleted records.

Key Changes:

    Update Logic: Modified the update method to ensure only books that are not marked as deleted can be updated.
    RBAC Implementation: Added security measures using Role-Based Access Control (RBAC) to restrict access to the update operation based on user roles.
    Authorization Guard: Integrated an Authorization Guard to ensure that only users with the correct role can perform the update action.
    Documentation: Updated the API documentation using Swagger to provide clear guidance on the new functionality.

Testing:

    Conducted tests using Postman to verify that the functionality works as intended and that security measures are enforced.